### PR TITLE
add ruby encoding 'magic comment' to file that contains multibyte character

### DIFF
--- a/app/helpers/filterer/pagination_helper.rb
+++ b/app/helpers/filterer/pagination_helper.rb
@@ -19,10 +19,10 @@ module Filterer
     def render_filterer_previous_link(filterer)
       content_tag(:li, class: filterer.meta[:page] == 1 ? "disabled" : '') do
         if filterer.meta[:page] == 1
-          content_tag(:span) { '‹' }
+          content_tag(:span) { '&rsaquo' }
         else
           content_tag(:a, class: 'pagination-previous',
-                      href: calculate_filterer_pagination_url(filterer.meta[:page] - 1)) { '‹' }
+                      href: calculate_filterer_pagination_url(filterer.meta[:page] - 1)) { '&lsaquo' }
         end
       end
     end
@@ -30,9 +30,9 @@ module Filterer
     def render_filterer_next_link(filterer)
       content_tag(:li, class: filterer.meta[:page] == filterer.meta[:last_page] ? "disabled" : '') do
         if filterer.meta[:page] == filterer.meta[:last_page]
-          content_tag(:span) { '›' }
+          content_tag(:span) { '&rsaquo' }
         else
-          content_tag(:a, class: 'pagination-next', href: calculate_filterer_pagination_url(filterer.meta[:page] + 1)) { '›' }
+          content_tag(:a, class: 'pagination-next', href: calculate_filterer_pagination_url(filterer.meta[:page] + 1)) { '&rsaquo' }
         end
       end
     end


### PR DESCRIPTION
Running under jruby, my application throws a `SyntaxError` due to the presence of a multi-byte character.  

```
SyntaxError: /vendor/bundle/jruby/1.9/gems/filterer-0.1.1/app/helpers/filterer/pagination_helper.rb:22: invalid multibyte char (US-ASCII)
```

This is fixed by adding the "magic comment" to declare the encoding of the file.

cc @adamjacobbecker
