### PR TITLE
Chainable sorts - obeying order params during `chain` calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ Now, when a user visits `/people`, they'll see Adam, Barack, and Joe, all three 
 
 #### Pagination
 
+Filterer supports basic pagination (described here). For advanced functionality or integrating with other gems, see [alternative solutions section](#alternative-pagination-solutions).
+
 In your controller:
 ```ruby
 helper Filterer::PaginationHelper
@@ -182,6 +184,8 @@ class PeopleController < ApplicationController
 end
 ```
 
+In the view, we can then skip the call to `results` (i.e. `@filterer.each` vs `@filterer.results.each`).
+
 By default, chaining will _not_ apply ordering clauses. To obey ordering params (as configured with `sort_option`), pass the `:include_ordering` option to `chain`:
 
 ```ruby
@@ -191,6 +195,22 @@ class PeopleController < ApplicationController
   end
 end
 ```
+
+#### Alternative Pagination Solutions
+
+Filterer supports basic pagination. This can be replaced by alternative pagination tools such as [Kaminari](https://github.com/amatsuda/kaminari) or [will_paginate](https://github.com/mislav/will_paginate).
+
+Using the `chain` approach, we can control pagination ourselves:
+
+```ruby
+class PeopleController < ApplicationController
+  def index
+    @filterer = PersonFilterer.chain(params, include_ordering: true).page(params[:page]).per(10)
+  end
+end
+```
+
+The views should then use the helpers appropriate for the pagination gem used.
 
 #### License
 [MIT](http://dobt.mit-license.org)

--- a/README.md
+++ b/README.md
@@ -170,6 +170,28 @@ class PersonFilterer < Filterer::Base
 end
 ```
 
+#### Chaining
+
+An option is available to chain additional calls onto the filterer query.
+
+```ruby
+class PeopleController < ApplicationController
+  def index
+    @filterer = PersonFilterer.chain(params).my_custom_method
+  end
+end
+```
+
+By default, chaining will _not_ apply ordering clauses. To obey ordering params (as configured with `sort_option`), pass the `:include_ordering` option to `chain`:
+
+```ruby
+class PeopleController < ApplicationController
+  def index
+    @filterer = PersonFilterer.chain(params, include_ordering: true).my_custom_method
+  end
+end
+```
+
 #### License
 [MIT](http://dobt.mit-license.org)
 

--- a/lib/filterer/base.rb
+++ b/lib/filterer/base.rb
@@ -86,8 +86,9 @@ module Filterer
     def find_results
       @results = opts.delete(:starting_query) || starting_query
       add_params_to_query
-      return if @opts[:chainable]
+      return if @opts[:chainable] && !@opts[:include_ordering]
       order_results
+      return if @opts[:chainable]
       add_meta
       return if @opts[:meta_only]
 


### PR DESCRIPTION
The default behaviour of _filterer_ is to omit the ordering clauses (`direction` and `sort` params) when calling `chain`. This patch allows an additional `:include_ordering` option (passed to `chain`) which changes this behaviour. 

The primary use case here is to facilitate usage of alternative / more feature-filled pagination gems, such as [Kaminari](https://github.com/amatsuda/kaminari).

I have documented the existing `chain` functionality as well as this new behaviour.

Based on discussion in #11.

Couldn't get my head around getting my new tests to work so this is untested.