### PR TITLE
Rename filter/chain methods to filterer/filterer_chain for Ruby 2.6

### DIFF
--- a/lib/filterer/active_record.rb
+++ b/lib/filterer/active_record.rb
@@ -7,8 +7,8 @@ module Filterer
         delegate_to_filterer(:filter, params, opts)
       end
 
-      def chain(params = {}, opts = {})
-        delegate_to_filterer(:chain, params, opts)
+      def filterer_chain(params = {}, opts = {})
+        delegate_to_filterer(:filterer_chain, params, opts)
       end
 
       private

--- a/lib/filterer/active_record.rb
+++ b/lib/filterer/active_record.rb
@@ -3,8 +3,8 @@ module Filterer
     extend ActiveSupport::Concern
 
     class_methods do
-      def filter(params = {}, opts = {})
-        delegate_to_filterer(:filter, params, opts)
+      def filterer(params = {}, opts = {})
+        delegate_to_filterer(:filterer, params, opts)
       end
 
       def filterer_chain(params = {}, opts = {})

--- a/lib/filterer/base.rb
+++ b/lib/filterer/base.rb
@@ -62,7 +62,7 @@ module Filterer
       end
 
       # @return [ActiveRecord::Association]
-      def chain(params = {}, opts = {})
+      def filterer_chain(params = {}, opts = {})
         new(params, opts.merge(
           skip_ordering: true,
           skip_pagination: true

--- a/lib/filterer/base.rb
+++ b/lib/filterer/base.rb
@@ -50,7 +50,7 @@ module Filterer
 
       # Public API
       # @return [ActiveRecord::Association]
-      def filter(params = {}, opts = {})
+      def filterer(params = {}, opts = {})
         new(params, opts).results
       end
 

--- a/lib/filterer/version.rb
+++ b/lib/filterer/version.rb
@@ -1,3 +1,3 @@
 module Filterer
-  VERSION = '2.0.0'
+  VERSION = '3.0.0'
 end

--- a/spec/lib/filterer/base_spec.rb
+++ b/spec/lib/filterer/base_spec.rb
@@ -387,7 +387,7 @@ describe Filterer::Base do
     it 'provides a helper method to skip both' do
       expect_any_instance_of(DefaultParamsFilterer).to_not receive(:ordered_results)
       expect_any_instance_of(DefaultParamsFilterer).to_not receive(:paginate_results)
-      filterer = DefaultParamsFilterer.chain({})
+      filterer = DefaultParamsFilterer.filterer_chain({})
     end
 
     it 'provides a helper method to skip pagination' do

--- a/spec/lib/filterer/base_spec.rb
+++ b/spec/lib/filterer/base_spec.rb
@@ -179,17 +179,17 @@ describe Filterer::Base do
 
   it 'applies default filters' do
     expect_any_instance_of(FakeQuery).to receive(:where).with(foo: 'bar').and_return(FakeQuery.new)
-    filterer = DefaultFiltersFilterer.filter({}, foo: 'bar')
+    filterer = DefaultFiltersFilterer.filterer({}, foo: 'bar')
   end
 
   it 'allows returning nil from default filters' do
     expect_any_instance_of(FakeQuery).to receive(:where).with(bar: 'baz').and_return(FakeQuery.new)
-    filterer = DefaultFiltersFilterer.filter({}).where(bar: 'baz')
+    filterer = DefaultFiltersFilterer.filterer({}).where(bar: 'baz')
   end
 
   it 'passes parameters to the correct methods' do
     expect_any_instance_of(SmokeTestFilterer).to receive(:param_foo).with('bar').and_return(FakeQuery.new)
-    SmokeTestFilterer.filter(foo: 'bar')
+    SmokeTestFilterer.filterer(foo: 'bar')
   end
 
   it 'does not pass blank parameters' do
@@ -198,7 +198,7 @@ describe Filterer::Base do
   end
 
   it 'allows returning nil from a param_* method' do
-    expect(ReturnNilFilterer.filter(foo: 'bar')).to eq([])
+    expect(ReturnNilFilterer.filterer(foo: 'bar')).to eq([])
   end
 
   describe 'sorting' do
@@ -376,12 +376,12 @@ describe Filterer::Base do
   describe 'options' do
     it 'skips ordering' do
       expect_any_instance_of(DefaultParamsFilterer).to_not receive(:ordered_results)
-      filterer = DefaultParamsFilterer.filter({}, skip_ordering: true)
+      filterer = DefaultParamsFilterer.filterer({}, skip_ordering: true)
     end
 
     it 'skips pagination' do
       expect_any_instance_of(DefaultParamsFilterer).to_not receive(:paginate_results)
-      filterer = DefaultParamsFilterer.filter({}, skip_pagination: true)
+      filterer = DefaultParamsFilterer.filterer({}, skip_pagination: true)
     end
 
     it 'provides a helper method to skip both' do


### PR DESCRIPTION
As discussed in https://github.com/dobtco/filterer/issues/24, the inclusion of the methods `chain` and `filter` by this gem conflict with Ruby 2.6's new [Enumerator::Chain](https://ruby-doc.org/core-2.6.3/Enumerator/Chain.html) and [Enumerable#filter](https://ruby-doc.org/core-2.6.1/Enumerable.html#method-i-filter) (see [details](https://blog.bigbinary.com/2018/08/28/ruby-2-6-adds-enumerable-filter-as-an-alias-of-enumerable-select.html)), resulting in broken behaviour.

This PR simply renames the `filter` method to `filterer` and the `chain` method to `filterer_chain` in order to bypass this conflict. Obviously, this requires a change in any client code, so would need a major version bump if accepted.

## TODO:
- [x] Rename `filter` to `filterer`
- [x] Rename `chain` to `filterer_chain`
- [ ] Update README usage instructions and migration for `filterer v3`!